### PR TITLE
Renaming Coq to Rocq

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Code of conduct #
 
-coq-community members are committed to maintaining a welcoming, civil and
+Rocq-community members are committed to maintaining a welcoming, civil and
 constructive environment. We expect the following standards to be observed and
-upheld by all participants in any coq-community forum (GitHub, Zulip, etc.).
+upheld by all participants in any Rocq-community forum (GitHub, Zulip, etc.).
 
 **Be respectful and inclusive.** Please do not use overtly sexual language or
 imagery, and do not attack anyone based on any aspect of personal identity,
@@ -13,14 +13,14 @@ prejudiced, sexual or political jokes and comments – even ones that you might
 consider acceptable in private. Ask yourself if a comment or statement might
 make someone feel unwelcomed or like an outsider.
 
-**Give credit.** All participants in coq-community are expected to respect
+**Give credit.** All participants in Rocq-community are expected to respect
 copyright laws and ethical attribution standards. This applies to both code and
 written materials, such as documentation or blog posts. Materials that violate
 the law, are plagiaristic, or ethically dubious in some way will be removed
 from officially-maintained lists of resources.
 
 If you believe one of these standards has been violated, please either file an
-issue on an appropriate repository, or contact any member of coq-community (at
+issue on an appropriate repository, or contact any member of Rocq-community (at
 your discretion). Keep in mind that most mistakes are due to ignorance rather
 than malice.
 
@@ -29,8 +29,8 @@ high-traffic forums do not generally have the bandwidth for extensive
 discourse. Consider writing a blog post if you feel that you have enough to say
 on a particular subject.
 
-**Get involved.** coq-community is built on a foundation of reciprocity and
-collaboration. Be aware that coq-community members contribute on a voluntary
+**Get involved.** Rocq-community is built on a foundation of reciprocity and
+collaboration. Be aware that Rocq-community members contribute on a voluntary
 basis, so ideas and bug reports are ok, but demands are not. Pull requests are
 always welcomed – see the [guidelines for contributing](CONTRIBUTING.md) to
 read about how to get started.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing guide #
 
 This is a shared contributing guide applying to all the projects of
-coq-community, including this meta-project.
+Rocq-community, including this meta-project.
 
 *Note this contributing guide itself is a work in progress and is meant to be
 collaboratively improved. Please contribute!*
@@ -10,7 +10,7 @@ collaboratively improved. Please contribute!*
 
 [Open a new issue using the appropriate template][move_project].
 Fill in the requested information. In particular here are some requirements to
-move a project to coq-community:
+move a project to Rocq-community:
 
 - The project must have a license that is either
   [approved as an open source license by OSI][osi-approved-license]
@@ -25,10 +25,10 @@ move a project to coq-community:
   packages are proposed without a volunteer maintainer, the corresponding
   issue will be labeled as looking for a maintainer until it finds one.
 
-## Contributing to a coq-community package ##
+## Contributing to a Rocq-community package ##
 
 - Report bugs on the specific project's issue tracker. Include as many details
-  as possible (version of the package and how you installed it, version of Coq,
+  as possible (version of the package and how you installed it, version of Rocq,
   version of OCaml if you built the package yourself...).
 
 - Propose changes by submitting a pull request. This implies that you accept to
@@ -37,13 +37,13 @@ move a project to coq-community:
   likely to be accepted.
 
   If you are working on a bug fix, report the bug first and self-assign the issue
-  (you need to be part of the coq-community organization to self-assign an issue,
+  (you need to be part of the Rocq-community organization to self-assign an issue,
   if you are not you may still post a comment saying you are working on this).
 
   If you have time on your hands but don't know what to work on, have a look
-  at [this list of coq-community issues where external help was requested][help-wanted].
+  at [this list of Rocq-community issues where external help was requested][help-wanted].
 
-## Maintaining a coq-community package ##
+## Maintaining a Rocq-community package ##
 
 As a maintainer, your main role is to handle incoming pull requests (review and
 merge them) and to make sure that incoming issues are not left without answer
@@ -51,7 +51,7 @@ merge them) and to make sure that incoming issues are not left without answer
 secondary maintainers.
 
 If you are unresponsive and there are no secondary maintainers, maintainers of
-other coq-community projects may act as secondary maintainers. If you are
+other Rocq-community projects may act as secondary maintainers. If you are
 unresponsive really often or if you wish to step down, you may be replaced by
 a new maintainer.
 
@@ -60,27 +60,27 @@ To replace a maintainer,
 
 Templates for setting up CI, an OPAM file, etc., [are available][templates]
 and advice and guidelines on how to maintain a project may be found in the
-[wiki](https://github.com/coq-community/manifesto/wiki).
+[wiki](https://github.com/rocq-community/manifesto/wiki).
 
 ## Contributing to this meta-project ##
 
-The processes and policies of coq-community are very much a work in progress.
+The processes and policies of Rocq-community are very much a work in progress.
 Always feel free to [open a meta-issue][meta] or a pull request to propose
 some improvements, discuss some policies, etc.
 
 Opening a pull request on this meta-project implies that you accept to put
 your contribution under the CC0 license: see [`LICENSE.md`](LICENSE.md).
 
-[move_project]: https://github.com/coq-community/manifesto/issues/new?labels=move-project&template=1-move-a-project.md&title=Proposal+to+move+project+X+to+coq-community
+[move_project]: https://github.com/rocq-community/manifesto/issues/new?labels=move-project&template=1-move-a-project.md&title=Proposal+to+move+project+X+to+rocq-community
 
 [osi-approved-license]: https://opensource.org/licenses/alphabetical
 
 [fsf-free-software-license]: https://www.gnu.org/licenses/license-list.html
 
-[change_maintainer]: https://github.com/coq-community/manifesto/issues/new?labels=change-maintainer&template=2-change-maintainer.md&title=Change+maintainer+of+project+X
+[change_maintainer]: https://github.com/rocq-community/manifesto/issues/new?labels=change-maintainer&template=2-change-maintainer.md&title=Change+maintainer+of+project+X
 
-[meta]: https://github.com/coq-community/manifesto/issues/new?labels=meta&template=3-meta.md
+[meta]: https://github.com/rocq-community/manifesto/issues/new?labels=meta&template=3-meta.md
 
-[templates]: https://github.com/coq-community/templates
+[templates]: https://github.com/rocq-community/templates
 
-[help-wanted]: https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Acoq-community+label%3A%22help+wanted%22
+[help-wanted]: https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Arocq-community+label%3A%22help+wanted%22

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 To the extent possible under law, the contributors of
-<https://github.com/coq-community/manifesto> have waived all copyright and
+<https://github.com/rocq-community/manifesto> have waived all copyright and
 related or neighboring rights to their contributions.
 
   <a rel="license"
@@ -7,7 +7,7 @@ related or neighboring rights to their contributions.
     <img src="https://licensebuttons.net/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
   </a>
 
-By contributing to <https://github.com/coq-community/manifesto>, you agree that
+By contributing to <https://github.com/rocq-community/manifesto>, you agree that
 you hold the copyright on your contribution and you agree to license your
 contribution under the CC0 license or you agree that you have permission
 to distribute your contribution under the CC0 license.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Projects can be hosted in Rocq-community whenever any of the following is the ca
 - the project is a tool of general interest and it makes sense to develop it
   collaboratively.
 
-Each project under the umbrella of rocq-community has one or several official
+Each project under the umbrella of Rocq-community has one or several official
 maintainer(s), but the maintenance effort is done collaboratively. Users need
-not be afraid of volunteering to be the official maintainer of a rocq-community
+not be afraid of volunteering to be the official maintainer of a Rocq-community
 project because they can step down at anytime. Changing the maintainer of a
-rocq-community project can be done very easily without the hassle of moving its
+Rocq-community project can be done very easily without the hassle of moving its
 location too.
 
 Maintenance is allowed to go much further than just updating the package to
@@ -72,7 +72,7 @@ including detailed documentation and exercises. Your contributions are welcome!
 
 ### Advertising interesting packages ###
 
-Not all the packages that are transferred to rocq-community have the same initial
+Not all the packages that are transferred to Rocq-community have the same initial
 quality. While this should not stop packages from being taken over, and new
 maintainers should strive to improve the package quality, some editorial work
 is also required to put forward the most interesting packages, be it for
@@ -210,7 +210,7 @@ editorial work.
 
 - **What kind of permissions do the members have?**
 
-  Members of the rocq-community organization have write-access to all
+  Members of the Rocq-community organization have write-access to all
   the repositories.  This permission should be used wisely: only minor
   fixes should be pushed without going through pull requests, and pull
   requests should preferably be approved by the project maintainer
@@ -238,13 +238,13 @@ editorial work.
 
 - **Why this name?**
 
-  The Rocq-community organization takes its inspiration from the similar-named
-  [elm-community](https://github.com/elm-community).
+  The Rocq-community organization takes its inspiration from the similarly-named
+  [Elm Community](https://github.com/elm-community).
   Here are some other sister organizations:
-  - [ocaml-community](https://github.com/ocaml-community/) (officially inspired
-    by elm-community and rocq-community)
-  - [nix-community](https://github.com/nix-community/)
-  - [reasonml-community](https://github.com/reasonml-community/)
+  - [OCaml Community](https://github.com/ocaml-community) (officially inspired
+    by Elm Community and Rocq-community)
+  - [Nix community projects](https://github.com/nix-community)
+  - [reasonml-community](https://github.com/reasonml-community)
 
 - **Who made this awesome logo?**
 

--- a/README.md
+++ b/README.md
@@ -3,33 +3,33 @@
 [![Zulip][zulip-shield]][zulip-link]
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
-[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+[contributing-link]: https://github.com/rocq-community/manifesto/blob/master/CONTRIBUTING.md
 
 [conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
-[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+[conduct-link]: https://github.com/rocq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
 
 [zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
-[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
+[zulip-link]: https://rocq-prover.zulipchat.com/#narrow/stream/237663-rocq-community-devs.20.26.20users
 
-# [![coq-community](logo.svg)](https://github.com/coq-community) #
+# [![Rocq-community](logo.svg)](https://github.com/rocq-community) #
 
 A project for a collaborative, community-driven effort for the long-term
-maintenance and advertisement of Coq packages.
+maintenance and advertisement of packages for the [Rocq Prover][rocq-prover].
 
 *Note that this README (the manifesto) is a work in progress and is meant to be
 collaboratively improved. Please contribute!*
 
 ## Who runs this organization? ##
 
-This organization is run by volunteer Coq users. Everyone is welcome
-(you don't need to be a very experienced Coq user to participate).
+This organization is run by volunteer Rocq users. Everyone is welcome
+(you don't need to be a very experienced Rocq user to participate).
 Please [get involved](CONTRIBUTING.md)!
 
 ## What are its goals? ##
 
-### Collaborative maintenance of Coq packages and tools ###
+### Collaborative maintenance of Rocq packages and tools ###
 
-Projects can be hosted in coq-community whenever any of the following is the case:
+Projects can be hosted in Rocq-community whenever any of the following is the case:
 
 - the initial author has stopped maintaining the project and someone else is
   volunteering to do so;
@@ -42,15 +42,15 @@ Projects can be hosted in coq-community whenever any of the following is the cas
 - the project is a tool of general interest and it makes sense to develop it
   collaboratively.
 
-Each project under the umbrella of coq-community has one or several official
+Each project under the umbrella of rocq-community has one or several official
 maintainer(s), but the maintenance effort is done collaboratively. Users need
-not be afraid of volunteering to be the official maintainer of a coq-community
+not be afraid of volunteering to be the official maintainer of a rocq-community
 project because they can step down at anytime. Changing the maintainer of a
-coq-community project can be done very easily without the hassle of moving its
+rocq-community project can be done very easily without the hassle of moving its
 location too.
 
 Maintenance is allowed to go much further than just updating the package to
-keep it compiling with newer Coq versions. It can also include refactorization
+keep it compiling with newer Rocq versions. It can also include refactorization
 of the code, uniformization of the style, merging with other packages, taking
 pieces out to put them in other libraries, and even removal of some parts that
 are not raising sufficient interest. These changes must, nonetheless, always be
@@ -59,27 +59,27 @@ plugin or tool that has users.
 
 ### Collaborative writing of documentation ###
 
-Some Coq proofs present a particular pedagogical interest because their
+Some Rocq proofs present a particular pedagogical interest because their
 statements are easy to understand, but they require some non-trivial
 mathematical tools and their mechanization illustrates interesting proof
 patterns, or demonstrate the use of specific libraries. They can be used as
 the basis for tutorials which explain the tricks and interesting parts.
 
-coq-community hosts several such documentation projects. Among them,
-[Hydras & Co.](https://github.com/coq-community/hydra-battles)
+Rocq-community hosts several such documentation projects. Among them,
+[Hydras & Co.](https://github.com/rocq-community/hydra-battles)
 collects libraries of formalized mathematics for inspiration and entertainment,
 including detailed documentation and exercises. Your contributions are welcome!
 
 ### Advertising interesting packages ###
 
-Not all the packages that are transferred to coq-community have the same initial
+Not all the packages that are transferred to rocq-community have the same initial
 quality. While this should not stop packages from being taken over, and new
 maintainers should strive to improve the package quality, some editorial work
 is also required to put forward the most interesting packages, be it for
 their usefulness as a library or plugin, because they demonstrate interesting
 proof techniques, or because they represent an important achievement.
 
-Currently, the [website](https://coq-community.org) highlights a selection of
+Currently, the [website](https://rocq-community.org) highlights a selection of
 packages with ⭐ and warns about some others with ⚠️ to inform users
 that some packages are more recommended for reuse than others.
 Come [chat with us][zulip-link] if you want to participate in this
@@ -96,7 +96,7 @@ editorial work.
 
 - **How to propose a new package?**
 
-  This process is documented [here](https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md#proposing-a-new-package).
+  This process is documented [here](https://github.com/rocq-community/manifesto/blob/master/CONTRIBUTING.md#proposing-a-new-package).
 
 - **Can I propose a project of which I am the author?**
 
@@ -106,74 +106,74 @@ editorial work.
   but if you become less available for this task, we'll be able to pass on this
   role to someone else.
 
-### Position in the Coq ecosystem ###
+### Position in the Rocq ecosystem ###
 
-- **What is the relation to Coq's Continuous Integration (CI)?**
+- **What is the relation to Rocq's Continuous Integration (CI)?**
 
-  [Coq's CI][Coq-CI] systematically tests a collection of external libraries
+  [Rocq's CI][rocq-ci] systematically tests a collection of external libraries
   and plugins for regression and compatiblity breakage with each proposed change to
-  Coq before integration. When a library or plugin in Coq's CI breaks, Coq developers
+  Rocq before integration. When a library or plugin in Rocq's CI breaks, Rocq developers
   or contributors will send patches or give instructions how to adapt to the proposed
-  change. A [subset][coq-community-ci] of coq-community packages are included in
-  Coq's CI, and the process of fixing such packages that break is straightforward
-  since Coq developers can themselves integrate the required changes.
+  change. A [subset][rocq-community-ci] of Rocq-community packages are included in
+  Rocq's CI, and the process of fixing such packages that break is straightforward
+  since Rocq developers can themselves integrate the required changes.
 
-- **What is the relation to the Coq package index?**
+- **What is the relation to the Rocq package index?**
 
-  The [Coq package index](https://coq.inria.fr/packages) is the present
-  way of distributing Coq packages using [opam][opam]. As such, all packages of
-  coq-community are meant to be listed in the Coq package index.
+  The [Rocq package index][package-index] is the present
+  way of distributing Rocq packages using [opam][opam]. As such, all packages of
+  Rocq-community are meant to be listed in the Rocq package index.
 
-- **What is the relation to the Coq Platform?**
+- **What is the relation to the Rocq Platform?**
 
-  The [Coq Platform][platform] is a continuously developed opam-based distribution of
-  Coq together with a curated selection of generally useful packages. The
-  Platform is currently the officially recommended way to install Coq. To ensure
-  that packages are compatible with Coq over time, Platform package maintainers
+  The [Rocq Platform][platform] is a continuously developed opam-based distribution of
+  Rocq together with a curated selection of generally useful packages. The
+  Platform is currently the officially recommended way to install Rocq. To ensure
+  that packages are compatible with Rocq over time, Platform package maintainers
   must agree to a form of social contract that, e.g., entails making timely
-  releases as Coq evolves. While a [subset][coq-community-platform] of coq-community
-  packages are also part of the Coq Platform and thus conform to Platform rules,
-  coq-community packages are not necessarily generally useful or compatible with
-  the Platform. To the Coq Platform, coq-community is one organization among many
+  releases as Rocq evolves. While a [subset][rocq-community-platform] of Rocq-community
+  packages are also part of the Rocq Platform and thus conform to Platform rules,
+  Rocq-community packages are not necessarily generally useful or compatible with
+  the Platform. To the Rocq Platform, Rocq-community is one organization among many
   that host Platform packages.
 
-- **What is the relation to coq-contribs?**
+- **What is the relation to rocq-archive?**
 
-  Coq's [contribs][contribs] represent the legacy distribution, compatibility testing
-  and maintenance model. There used to be a form allowing users to submit a package
-  that the Coq development team would then maintain. While distribution now
-  happens through the Coq package index and compatibility testing is done via
-  Coq's CI, maintenance of legacy contribs is done less regularly.
+  [rocq-archive][archive] contains mainly repositories from the old contribs distribution,
+  compatibility testing and maintenance model for Coq. There used to be a form allowing
+  users to submit a package that the Coq development team would then maintain.
+  While distribution now happens through the Rocq package index and compatibility
+  testing is done via Rocq's CI, maintenance of legacy contribs is not done regularly.
 
-  coq-community is a proposed replacement for the long-term maintenance of
-  Coq packages. Whereas contribs were maintained by the Coq development team,
-  coq-community is managed by the user community. We encourage users to
+  Rocq-community is a proposed replacement for the long-term maintenance of
+  Rocq packages. Whereas contribs were maintained by the Coq development team,
+  Rocq-community is managed by the user community. We encourage users to
   “adopt” a package (including a legacy contrib) and to push the meaning of
   “maintenance” further than simply ensuring that the package continues to
-  compile with newer Coq versions.
+  compile with newer Rocq versions.
 
 ### Best practices ###
 
-- **Do the projects of coq-community need to have some Continous Integration (CI) setup?**
+- **Do the projects of Rocq-community need to have some Continous Integration (CI) setup?**
 
   Yes, CI plays a big role in keeping code projects more stable over time. In
-  the case of a Coq package, it helps to ensure that the project stays
-  compatible with the various versions of Coq that are claimed to be supported
-  (as well as various versions of OCaml in the case of a Coq plugin).
+  the case of a Rocq package, it helps to ensure that the project stays
+  compatible with the various versions of Rocq that are claimed to be supported
+  (as well as various versions of OCaml in the case of a Rocq plugin).
 
-  Templates for CI and other Coq-related configuration files are
+  Templates for CI and other Rocq-related configuration files are
   maintained in the [templates][templates] repository.
 
-- **Which versions of Coq must be supported by projects of coq-community?**
+- **Which versions of Rocq must be supported by projects of Rocq-community?**
 
-  At least the last stable version of Coq must be supported at any given time.
-  Support for older versions or the development version of Coq can be decided
-  project by project. Note that supporting the development version of Coq is
-  a requirement to get into [Coq's CI][Coq-CI], which can be interesting to get
-  patches from Coq developers when they introduce a breaking change (this is
+  At least the last stable version of Rocq must be supported at any given time.
+  Support for older versions or the development version of Rocq can be decided
+  project by project. Note that supporting the development version of Rocq is
+  a requirement to get into [Rocq's CI][rocq-ci], which can be interesting to get
+  patches from Rocq developers when they introduce a breaking change (this is
   particularly recommended for plugins).
 
-- **What license to use for a coq-community project?**
+- **What license to use for a Rocq-community project?**
 
   The only strict requirement is to use a license that is either
   [approved as an open source license by OSI][osi-approved-license]
@@ -210,7 +210,7 @@ editorial work.
 
 - **What kind of permissions do the members have?**
 
-  Members of the coq-community organization have write-access to all
+  Members of the rocq-community organization have write-access to all
   the repositories.  This permission should be used wisely: only minor
   fixes should be pushed without going through pull requests, and pull
   requests should preferably be approved by the project maintainer
@@ -231,50 +231,54 @@ editorial work.
 
   We will have a governance process to make sure that we can handle conflicts
   that are bound to arise about the management of specific projects. Please
-  contribute to [meta-issue #2](https://github.com/coq-community/manifesto/issues/2)
+  contribute to [meta-issue #2](https://github.com/rocq-community/manifesto/issues/2)
   which is about this.
 
 ### History ###
 
 - **Why this name?**
 
-  The coq-community organization takes its inspiration from the similar-named
+  The Rocq-community organization takes its inspiration from the similar-named
   [elm-community](https://github.com/elm-community).
   Here are some other sister organizations:
   - [ocaml-community](https://github.com/ocaml-community/) (officially inspired
-    by elm-community and coq-community)
+    by elm-community and rocq-community)
   - [nix-community](https://github.com/nix-community/)
   - [reasonml-community](https://github.com/reasonml-community/)
 
 - **Who made this awesome logo?**
 
   This logo was designed by Aras from the [openlogos project][openlogos] and
-  was attributed to coq-community following a general mobilization of Coq users.
+  was attributed to Rocq-community following a general mobilization of users.
   Thanks to Aras and to the 94 people who voted for us to get this logo!
 
 Is anything still unclear? Please [open an issue][meta] or
 [chat on Zulip][zulip-link] to ask a question.
 
+[rocq-prover]: https://rocq-prover.org
+
 [osi-approved-license]: https://opensource.org/licenses/alphabetical
 
 [fsf-free-software-license]: https://www.gnu.org/licenses/license-list.html
 
-[archive]: https://github.com/coq-community?utf8=%E2%9C%93&q=&type=archived
+[archive]: https://github.com/rocq-community?utf8=%E2%9C%93&q=&type=archived
 
-[Coq-CI]: https://github.com/coq/coq/blob/master/dev/ci/README.md
+[rocq-ci]: https://github.com/coq/coq/blob/master/dev/ci/README.md
 
-[meta]: https://github.com/coq-community/manifesto/issues/new?template=meta.md
+[meta]: https://github.com/rocq-community/manifesto/issues/new?template=meta.md
 
 [openlogos]: https://github.com/arasatasaygin/openlogos
 
-[templates]: https://github.com/coq-community/templates
+[templates]: https://github.com/rocq-community/templates
 
-[contribs]: https://github.com/coq-contribs
+[archive]: https://github.com/rocq-archive
+
+[package-index]: https://rocq-prover.org/packages
 
 [platform]: https://github.com/coq/platform
 
-[coq-community-platform]: https://github.com/search?q=topic%3Acoq-platform+org%3Acoq-community&type=Repositories
+[rocq-community-platform]: https://github.com/search?q=topic%3Acoq-platform+org%3Arocq-community&type=Repositories
 
-[coq-community-ci]: https://github.com/search?q=topic%3Acoq-ci+org%3Acoq-community&type=Repositories
+[rocq-community-ci]: https://github.com/search?q=topic%3Acoq-ci+org%3Arocq-community&type=Repositories
 
 [opam]: https://opam.ocaml.org


### PR DESCRIPTION
This is a conservative initial pass at renaming Coq to Rocq in `.md` files. I suggest merging this quickly and doing a followup PR when the `coq` GitHub organization is renamed.